### PR TITLE
Upload as html with links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ When application is executed with `uploadType = TOOLKIT_DOCS', then item file is
 **startDate** - start date of diff given in format `yyyy-MM-dd`.<br />
 **endDate** - end date of diff given in format `yyyy-MM-dd`. By default it is set as now.<br />
 **itemFileNamePrefix** - if given then this value will be used as prefix of the diff file name.<br />
+**useAsFileName** - when set as `Y` then `itemFileNamePrefix` is used as file name for produced item. Default value is `N`.<br />
 **gitAuthor** - author specific for git repository stored at git config under key '_user.name_'. When used together with _author_, this parameter has higher priority.<br />
 **mercurialAuthor** - author specific for mercurial repository. When used together with _author_, this parameter has higher priority.<br />
 **svnAuthor** - author specific for svn repository. When used together with _author_, this parameter has higher priority.<br />

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Below parameters are mandatory for toolkit:<br/>
 **toolkitPassword** - user password used to log in into SharePoint.<br /><br />
 **toolkitProjectListNames** - comma separated names of the folders to scan on toolkit, when looking for changes in documents made by user. Default value is `Deliverables`.<br/>
 **deleteDownloadedFiles** - if `Y` then all downloaded files from toolkit will be downloaded afterwards. This parameter works together with upload type `TOOLKIT_DOCS`<br/>
+**uploadAsHtml** - if `Y` then item will be produced as html file with links to actual documents. This option is recommended when fat in size documents has bean changed. This parameter works together with upload type `TOOLKIT_DOCS` and default value is `N`.<br/>
 
 _Note:_ When `periodInDays` is used together with `startDate` then **startDate** has higher priority.
 ### Explanation of *uploadType* parameter

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pg.gipter</groupId>
     <artifactId>Gipter</artifactId>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
     <packaging>jar</packaging>
 
     <build>

--- a/src/main/java/pg/gipter/producer/ToolkitDocumentsDiffProducer.java
+++ b/src/main/java/pg/gipter/producer/ToolkitDocumentsDiffProducer.java
@@ -38,7 +38,9 @@ class ToolkitDocumentsDiffProducer extends AbstractDiffProducer {
         if (documents.isEmpty()) {
             logger.warn("No documents to zip is no item to upload. [{}].", UploadType.TOOLKIT_DOCS);
             throw new IllegalArgumentException("Given projects do not contain any items.");
-        } else {
+        }
+
+        if (!applicationProperties.isUploadAsHtml()) {
             zipDocumentsAndWriteToFile(documents);
             if (applicationProperties.isDeleteDownloadedFiles()) {
                 deleteFiles(documents);

--- a/src/main/java/pg/gipter/producer/processor/AbstractDocumentFinder.java
+++ b/src/main/java/pg/gipter/producer/processor/AbstractDocumentFinder.java
@@ -187,7 +187,7 @@ abstract class AbstractDocumentFinder implements DocumentFinder {
         return result;
     }
 
-    Map<String, String> getFilesToDownload(List<DocumentDetails> documentDetails) {
+    final Map<String, String> getFilesToDownload(List<DocumentDetails> documentDetails) {
         Map<String, String> filesToDownloadMap = new HashMap<>();
         for (DocumentDetails dd : documentDetails) {
             if (dd.getVersions().isEmpty() && dd.getLastModifier().getLoginName().equals(applicationProperties.toolkitUsername())) {
@@ -246,7 +246,7 @@ abstract class AbstractDocumentFinder implements DocumentFinder {
         return filesToDownloadMap;
     }
 
-    private String getFullDownloadUrl(String fileReference) {
+    String getFullDownloadUrl(String fileReference) {
         return String.format("%s%s", applicationProperties.toolkitUrl(), fileReference);
     }
 

--- a/src/main/java/pg/gipter/producer/processor/DocumentFinderFactory.java
+++ b/src/main/java/pg/gipter/producer/processor/DocumentFinderFactory.java
@@ -12,6 +12,9 @@ public final class DocumentFinderFactory {
         if (LocalDate.now().isAfter(applicationProperties.endDate())) {
             //return new ComplexDocumentFinder(applicationProperties);
         }
+        if (applicationProperties.isUploadAsHtml()) {
+            return new HtmlDocumentFinder(applicationProperties);
+        }
         return new SimpleDocumentFinder(applicationProperties);
     }
 }

--- a/src/main/java/pg/gipter/producer/processor/HtmlDocument.java
+++ b/src/main/java/pg/gipter/producer/processor/HtmlDocument.java
@@ -1,0 +1,41 @@
+package pg.gipter.producer.processor;
+
+import java.time.LocalDateTime;
+
+class HtmlDocument {
+
+    private final String fileName;
+    private final double version;
+    private final LocalDateTime modificationDate;
+    private final String link;
+
+    HtmlDocument(String fileName, double version, LocalDateTime modificationDate, String link) {
+        this.fileName = fileName;
+        this.version = version;
+        this.modificationDate = modificationDate;
+        this.link = link;
+    }
+
+    String getTitle() {
+        if (fileName.lastIndexOf(".") > 0) {
+            return fileName.substring(0, fileName.lastIndexOf("."));
+        }
+        return getFileName();
+    }
+
+    String getFileName() {
+        return fileName;
+    }
+
+    double getVersion() {
+        return version;
+    }
+
+    LocalDateTime getModificationDate() {
+        return modificationDate;
+    }
+
+    String getLink() {
+        return link;
+    }
+}

--- a/src/main/java/pg/gipter/producer/processor/HtmlDocumentFinder.java
+++ b/src/main/java/pg/gipter/producer/processor/HtmlDocumentFinder.java
@@ -1,0 +1,179 @@
+package pg.gipter.producer.processor;
+
+import com.google.gson.JsonObject;
+import org.apache.commons.io.FileUtils;
+import pg.gipter.producer.command.UploadType;
+import pg.gipter.settings.ApplicationProperties;
+import pg.gipter.toolkit.dto.DocumentDetails;
+import pg.gipter.toolkit.dto.VersionDetails;
+import pg.gipter.utils.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+class HtmlDocumentFinder extends SimpleDocumentFinder {
+
+    HtmlDocumentFinder(ApplicationProperties applicationProperties) {
+        super(applicationProperties);
+    }
+
+    @Override
+    public List<File> find() {
+        List<String> urls = buildFullUrls();
+        List<JsonObject> items = getItems(urls);
+        List<DocumentDetails> documentDetails = items.stream()
+                .map(this::convertToDocumentDetails)
+                .flatMap(List::stream)
+                .filter(dd -> !StringUtils.nullOrEmpty(dd.getDocType()))
+                .collect(toList());
+        if (documentDetails.isEmpty()) {
+            logger.error("Can not find [{}] to upload as your copyright items.", UploadType.TOOLKIT_DOCS);
+            throw new IllegalArgumentException("Can not find items to upload.");
+        }
+
+        List<HtmlDocument> htmlDocuments = getHtmlDocuments(documentDetails);
+        try {
+            return Stream.of(createFile(createHtml(htmlDocuments))).collect(toList());
+        } catch (IOException e) {
+            String errorMsg = "Can not create html file to upload as your copyright item.";
+            logger.error(errorMsg, e);
+            throw new IllegalArgumentException(errorMsg, e);
+        }
+    }
+
+    List<HtmlDocument> getHtmlDocuments(List<DocumentDetails> documentDetails) {
+        List<HtmlDocument> htmlDocuments = new LinkedList<>();
+        for (DocumentDetails dd : documentDetails) {
+            if (dd.getVersions().isEmpty() && dd.getLastModifier().getLoginName().equals(applicationProperties.toolkitUsername())) {
+                HtmlDocument htmlDocument = new HtmlDocument(dd.getFileLeafRef(), Double.valueOf(dd.getCurrentVersion()), dd.getCreated(), dd.getFileRef());
+                htmlDocuments.add(htmlDocument);
+            } else if (!dd.getVersions().isEmpty()) {
+                Optional<VersionDetails> minMe;
+                double minMeCurrentVersion = 0;
+                do {
+                    final double currentVersion = minMeCurrentVersion;
+                    minMe = dd.getVersions().stream()
+                            .filter(vd -> vd.getCreator().getLoginName().equalsIgnoreCase(applicationProperties.toolkitUsername()))
+                            .filter(vd -> vd.getCreated().isAfter(LocalDateTime.of(applicationProperties.startDate(), LocalTime.now())))
+                            .filter(vd -> vd.getCreated().isBefore(LocalDateTime.of(applicationProperties.endDate(), LocalTime.now())))
+                            .filter(vd -> vd.getVersionLabel() > currentVersion)
+                            .min(Comparator.comparingDouble(VersionDetails::getVersionLabel));
+
+                    if (minMe.isPresent()) {
+                        final VersionDetails minMeV = minMe.get();
+                        dd.getVersions().stream()
+                                .filter(vd -> !vd.getCreator().getLoginName().equalsIgnoreCase(applicationProperties.toolkitUsername()))
+                                .filter(vd -> vd.getVersionLabel() < minMeV.getVersionLabel())
+                                .max(Comparator.comparingDouble(VersionDetails::getVersionLabel))
+                                .map(versionDetails -> new HtmlDocument(
+                                        dd.getFileLeafRef(),
+                                        versionDetails.getVersionLabel(),
+                                        versionDetails.getCreated(),
+                                        getFullDownloadUrl(dd.getProject() + versionDetails.getDownloadUrl())
+                                ))
+                                .ifPresent(htmlDocuments::add);
+                        double difference = 0.0;
+                        Optional<VersionDetails> nextMinMe;
+                        do {
+                            final double diff = ++difference;
+                            nextMinMe = dd.getVersions().stream()
+                                    .filter(vd -> vd.getCreator().getLoginName().equalsIgnoreCase(applicationProperties.toolkitUsername()))
+                                    .filter(vd -> vd.getCreated().isAfter(LocalDateTime.of(applicationProperties.startDate(), LocalTime.now())))
+                                    .filter(vd -> vd.getCreated().isBefore(LocalDateTime.of(applicationProperties.endDate(), LocalTime.now())))
+                                    .filter(vd -> vd.getVersionLabel() > minMeV.getVersionLabel())
+                                    .filter(vd -> vd.getVersionLabel() - minMeV.getVersionLabel() == diff)
+                                    .min(Comparator.comparingDouble(VersionDetails::getVersionLabel));
+                            if (nextMinMe.isPresent()) {
+                                minMe = nextMinMe;
+                            }
+                        } while (nextMinMe.isPresent() &&
+                                nextMinMe.get().getVersionLabel() < Double.valueOf(dd.getCurrentVersion())
+                        );
+
+                        String downloadUrl = getFullDownloadUrl(dd.getProject() + minMe.get().getDownloadUrl());
+                        if (minMe.get().getDownloadUrl().startsWith(dd.getProject())) {
+                            downloadUrl = getFullDownloadUrl(minMe.get().getDownloadUrl());
+                        }
+
+                        htmlDocuments.add(new HtmlDocument(
+                                dd.getFileLeafRef(),
+                                minMe.get().getVersionLabel(),
+                                minMe.get().getCreated(),
+                                downloadUrl
+                        ));
+
+                        minMeCurrentVersion = minMe.get().getVersionLabel();
+                    }
+                } while (minMe.isPresent() && minMe.get().getVersionLabel() < Double.valueOf(dd.getCurrentVersion()));
+            }
+        }
+        return htmlDocuments;
+    }
+
+    String createHtml(List<HtmlDocument> htmlDocuments) {
+        StringBuilder builder = new StringBuilder("<!DOCTYPE html>");
+        builder.append("<html>");
+        builder.append("<head>")
+                .append("<style>")
+                    .append("table, th, td {border: 1px solid black; border-collapse: collapse;}")
+                    .append("th, td { padding: 5px; text-align: left;}")
+                .append("</style>")
+        .append("</head>");
+
+        builder.append("<body>");
+        builder.append("<h2>Copyright item</h2>");
+        builder.append("<p>")
+                .append("Item generated from ")
+                .append(applicationProperties.startDate().format(ApplicationProperties.yyyy_MM_dd))
+                .append(" to ")
+                .append(applicationProperties.endDate().format(ApplicationProperties.yyyy_MM_dd))
+                .append(".</p>");
+
+        builder.append("<table style=\"width:100%\">");
+        builder.append("<tr>");
+        builder.append("<th>Title</th>");
+        builder.append("<th>Version</th>");
+        builder.append("<th>Modification date</th>");
+        builder.append("<th>Link</th>");
+        builder.append("</tr>");
+
+        for (HtmlDocument htmlDocument : htmlDocuments) {
+            builder.append("<tr>");
+            builder.append("<td>")
+                    .append("<nobr>")
+                        .append(htmlDocument.getTitle())
+                        .append("</nobr>")
+                    .append("</td>");
+            builder.append("<td>").append(htmlDocument.getVersion()).append("</td>");
+            builder.append("<td>").append(htmlDocument.getModificationDate().format(DateTimeFormatter.ISO_DATE_TIME)).append("</td>");
+            builder.append("<td>")
+                    .append("<a target=\"_blank\" href=\"")
+                        .append(htmlDocument.getLink().replaceAll(" ", "%20"))
+                        .append("\">")
+                            .append(htmlDocument.getLink().replaceAll(" ", "%20"))
+                        .append("</a>")
+                    .append("</td>");
+            builder.append("</tr>");
+        }
+        builder.append("</table></body></html>");
+
+        return builder.toString();
+    }
+
+    File createFile(String content) throws IOException {
+        File htmlFile = new File(applicationProperties.itemPath());
+        FileUtils.write(htmlFile, content, StandardCharsets.UTF_8);
+        return htmlFile;
+    }
+}

--- a/src/main/java/pg/gipter/settings/ApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/ApplicationProperties.java
@@ -106,11 +106,19 @@ public abstract class ApplicationProperties {
                 fileName = String.format("%s-%s", itemFileNamePrefix(), fileName);
             }
         }
+        String extension = getFileExtension();
+        return fileName + "." + extension;
+    }
+
+    String getFileExtension() {
         String extension = "txt";
         if (uploadType() == UploadType.TOOLKIT_DOCS) {
             extension = "zip";
+            if (isUploadAsHtml()) {
+                extension = "html";
+            }
         }
-        return fileName + "." + extension;
+        return extension;
     }
 
     public PreferredArgSource preferredArgSource() {
@@ -162,8 +170,11 @@ public abstract class ApplicationProperties {
                 ", toolkitDomain='" + toolkitDomain() + '\'' +
                 ", toolkitCopyListName='" + toolkitCopyListName() + '\'' +
                 ", toolkitUserFolder='" + toolkitUserFolder() + '\'' +
-                ", toolkitProjectListNames='" + String.join(",", toolkitProjectListNames()) + '\''
-                ;
+                ", toolkitProjectListNames='" + String.join(",", toolkitProjectListNames()) + '\'' +
+                ", deleteDownloadedFiles='" + isDeleteDownloadedFiles() + '\'' +
+                ", enableOnStartup='" + isEnableOnStartup() + '\'' +
+                ", uploadAsHtml='" + isUploadAsHtml() + '\''
+        ;
     }
 
     public abstract Set<String> authors();
@@ -192,4 +203,5 @@ public abstract class ApplicationProperties {
     public abstract boolean isActiveTray();
     public abstract boolean isDeleteDownloadedFiles();
     public abstract boolean isEnableOnStartup();
+    public abstract boolean isUploadAsHtml();
 }

--- a/src/main/java/pg/gipter/settings/ApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/ApplicationProperties.java
@@ -100,7 +100,11 @@ public abstract class ApplicationProperties {
             ).toLowerCase();
         }
         if (!itemFileNamePrefix().isEmpty()) {
-            fileName = String.format("%s-%s", itemFileNamePrefix(), fileName);
+            if (isUseAsFileName()) {
+                fileName = itemFileNamePrefix();
+            } else {
+                fileName = String.format("%s-%s", itemFileNamePrefix(), fileName);
+            }
         }
         String extension = "txt";
         if (uploadType() == UploadType.TOOLKIT_DOCS) {
@@ -142,6 +146,7 @@ public abstract class ApplicationProperties {
                 ", itemPath='" + itemPath() + '\'' +
                 ", fileName='" + fileName() + '\'' +
                 ", projectPath='" + String.join(",", projectPaths()) + '\'' +
+                ", useAsFileName='" + isUseAsFileName() + '\'' +
                 ", periodInDays='" + periodInDays() + '\'' +
                 ", startDate='" + startDate() + '\'' +
                 ", endDate='" + endDate() + '\'' +
@@ -168,6 +173,7 @@ public abstract class ApplicationProperties {
     public abstract String itemPath();
     public abstract Set<String> projectPaths();
     public abstract String itemFileNamePrefix();
+    public abstract boolean isUseAsFileName();
     public abstract String committerEmail();
     public abstract LocalDate startDate();
     public abstract LocalDate endDate();

--- a/src/main/java/pg/gipter/settings/ArgExtractor.java
+++ b/src/main/java/pg/gipter/settings/ArgExtractor.java
@@ -226,4 +226,11 @@ final class ArgExtractor {
         }
         return StringUtils.getBoolean(ArgName.enableOnStartup.defaultValue());
     }
+
+    boolean isUseAsFileName() {
+        if (containsArg(ArgName.useAsFileName.name())) {
+            return StringUtils.getBoolean(getValue(ArgName.useAsFileName, ArgName.useAsFileName.defaultValue()));
+        }
+        return StringUtils.getBoolean(ArgName.useAsFileName.defaultValue());
+    }
 }

--- a/src/main/java/pg/gipter/settings/ArgExtractor.java
+++ b/src/main/java/pg/gipter/settings/ArgExtractor.java
@@ -233,4 +233,11 @@ final class ArgExtractor {
         }
         return StringUtils.getBoolean(ArgName.useAsFileName.defaultValue());
     }
+
+    boolean isUploadAsHtml() {
+        if (containsArg(ArgName.uploadAsHtml.name())) {
+            return StringUtils.getBoolean(getValue(ArgName.uploadAsHtml, ArgName.uploadAsHtml.defaultValue()));
+        }
+        return StringUtils.getBoolean(ArgName.uploadAsHtml.defaultValue());
+    }
 }

--- a/src/main/java/pg/gipter/settings/ArgName.java
+++ b/src/main/java/pg/gipter/settings/ArgName.java
@@ -19,6 +19,7 @@ public enum ArgName {
     itemPath("NO_ITEM_PATH_GIVEN"),
     projectPath("NO_PROJECT_PATH_GIVEN"),
     itemFileNamePrefix(""),
+    useAsFileName("N"),
 
     periodInDays("7"),
     startDate(LocalDate.now().minusDays(Integer.parseInt(periodInDays.defaultValue)).format(yyyy_MM_dd)),

--- a/src/main/java/pg/gipter/settings/ArgName.java
+++ b/src/main/java/pg/gipter/settings/ArgName.java
@@ -41,7 +41,8 @@ public enum ArgName {
     toolkitWSUrl(toolkitUrl.defaultValue + toolkitCopyCase.defaultValue + "/_vti_bin/lists.asmx"),
     toolkitUserFolder(toolkitUrl.defaultValue + toolkitCopyCase.defaultValue + "/Lists/" + toolkitCopyListName.defaultValue + "/"),
     toolkitProjectListNames("Deliverables"),
-    deleteDownloadedFiles("Y");
+    deleteDownloadedFiles("Y"),
+    uploadAsHtml("N");
 
     private String defaultValue;
 

--- a/src/main/java/pg/gipter/settings/CliPreferredApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/CliPreferredApplicationProperties.java
@@ -270,4 +270,14 @@ class CliPreferredApplicationProperties extends ApplicationProperties {
         return false;
     }
 
+    @Override
+    public boolean isUseAsFileName() {
+        boolean useAsFileName = argExtractor.isUseAsFileName();
+        String argName = ArgName.useAsFileName.name();
+        if (!containsArg(argName) && containsProperty(argName)) {
+            useAsFileName = StringUtils.getBoolean(properties.getProperty(argName, String.valueOf(useAsFileName)));
+        }
+        return useAsFileName;
+    }
+
 }

--- a/src/main/java/pg/gipter/settings/CliPreferredApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/CliPreferredApplicationProperties.java
@@ -280,4 +280,14 @@ class CliPreferredApplicationProperties extends ApplicationProperties {
         return useAsFileName;
     }
 
+    @Override
+    public boolean isUploadAsHtml() {
+        boolean uploadAsHtml = argExtractor.isUploadAsHtml();
+        String argName = ArgName.uploadAsHtml.name();
+        if (!containsArg(argName) && containsProperty(argName)) {
+            uploadAsHtml = StringUtils.getBoolean(properties.getProperty(argName, String.valueOf(uploadAsHtml)));
+        }
+        return uploadAsHtml;
+    }
+
 }

--- a/src/main/java/pg/gipter/settings/FilePreferredApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/FilePreferredApplicationProperties.java
@@ -265,4 +265,14 @@ class FilePreferredApplicationProperties extends ApplicationProperties {
         return argExtractor.isUseAsFileName();
     }
 
+    @Override
+    public boolean isUploadAsHtml() {
+        if (hasProperties()) {
+            return StringUtils.getBoolean(properties.getProperty(
+                    ArgName.uploadAsHtml.name(), ArgName.uploadAsHtml.defaultValue()
+            ));
+        }
+        return argExtractor.isUploadAsHtml();
+    }
+
 }

--- a/src/main/java/pg/gipter/settings/FilePreferredApplicationProperties.java
+++ b/src/main/java/pg/gipter/settings/FilePreferredApplicationProperties.java
@@ -255,4 +255,14 @@ class FilePreferredApplicationProperties extends ApplicationProperties {
         return argExtractor.isEnableOnStartup();
     }
 
+    @Override
+    public boolean isUseAsFileName() {
+        if (hasProperties()) {
+            return StringUtils.getBoolean(properties.getProperty(
+                    ArgName.useAsFileName.name(), ArgName.useAsFileName.defaultValue()
+            ));
+        }
+        return argExtractor.isUseAsFileName();
+    }
+
 }

--- a/src/main/java/pg/gipter/ui/main/MainController.java
+++ b/src/main/java/pg/gipter/ui/main/MainController.java
@@ -80,6 +80,8 @@ public class MainController extends AbstractController {
     private Button projectPathButton;
     @FXML
     private Button itemPathButton;
+    @FXML
+    private CheckBox useAsFileNameCheckBox;
 
     @FXML
     private DatePicker startDatePicker;
@@ -159,6 +161,7 @@ public class MainController extends AbstractController {
         String itemPath = applicationProperties.itemPath().substring(0, applicationProperties.itemPath().indexOf(itemFileName) - 1);
         itemPathLabel.setText(itemPath);
         itemFileNamePrefixTextField.setText(applicationProperties.itemFileNamePrefix());
+        useAsFileNameCheckBox.setSelected(applicationProperties.isUseAsFileName());
 
         startDatePicker.setValue(LocalDate.now().minusDays(applicationProperties.periodInDays()));
         endDatePicker.setValue(LocalDate.now());
@@ -208,13 +211,15 @@ public class MainController extends AbstractController {
 
         startDatePicker.setConverter(dateConverter());
         endDatePicker.setConverter(dateConverter());
-        endDatePicker.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        authorsTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        committerEmailTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        gitAuthorTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        svnAuthorTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        mercurialAuthorTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
-        skipRemoteCheckBox.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
+
+        endDatePicker.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        authorsTextField.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        committerEmailTextField.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        gitAuthorTextField.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        svnAuthorTextField.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        mercurialAuthorTextField.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+        skipRemoteCheckBox.setDisable(applicationProperties.uploadType() == UploadType.TOOLKIT_DOCS);
+
         activeteTrayCheckBox.setDisable(!uiLauncher.isTraySupported());
         autostartCheckBox.setDisable(!uiLauncher.isTraySupported());
         progressIndicator.setVisible(false);
@@ -345,6 +350,7 @@ public class MainController extends AbstractController {
         if (!StringUtils.nullOrEmpty(itemFileNamePrefixTextField.getText())) {
             argList.add(ArgName.itemFileNamePrefix + "=" + itemFileNamePrefixTextField.getText());
         }
+        argList.add(ArgName.useAsFileName + "=" + useAsFileNameCheckBox.isSelected());
 
         if (!startDatePicker.getValue().format(yyyy_MM_dd).equals(ArgName.startDate.defaultValue()) &&
                 !startDatePicker.getValue().isEqual(LocalDate.now().minusDays(Integer.valueOf(periodInDaysTextField.getText())))) {

--- a/src/main/java/pg/gipter/ui/main/MainController.java
+++ b/src/main/java/pg/gipter/ui/main/MainController.java
@@ -69,6 +69,8 @@ public class MainController extends AbstractController {
     private TextField toolkitProjectListNamesTextField;
     @FXML
     private CheckBox deleteDownloadedFilesCheckBox;
+    @FXML
+    private CheckBox uploadAsHtmlCheckBox;
 
     @FXML
     private Label projectPathLabel;
@@ -155,6 +157,7 @@ public class MainController extends AbstractController {
         toolkitUserFolderTextField.setText(applicationProperties.toolkitUserFolder());
         toolkitProjectListNamesTextField.setText(String.join(",", applicationProperties.toolkitProjectListNames()));
         deleteDownloadedFilesCheckBox.setSelected(applicationProperties.isDeleteDownloadedFiles());
+        uploadAsHtmlCheckBox.setSelected(applicationProperties.isUploadAsHtml());
 
         projectPathLabel.setText(String.join(",", applicationProperties.projectPaths()));
         String itemFileName = Paths.get(applicationProperties.itemPath()).getFileName().toString();
@@ -194,7 +197,8 @@ public class MainController extends AbstractController {
         toolkitWSTextField.setEditable(false);
         toolkitUserFolderTextField.setEditable(false);
         toolkitProjectListNamesTextField.setDisable(applicationProperties.uploadType() != UploadType.TOOLKIT_DOCS);
-        deleteDownloadedFilesCheckBox.setDisable(applicationProperties.uploadType() != UploadType.TOOLKIT_DOCS);
+        deleteDownloadedFilesCheckBox.setDisable(applicationProperties.uploadType() != UploadType.TOOLKIT_DOCS || applicationProperties.isUploadAsHtml());
+        uploadAsHtmlCheckBox.setDisable(applicationProperties.uploadType() != UploadType.TOOLKIT_DOCS);
 
         if (applicationProperties.projectPaths().isEmpty()) {
             projectPathButton.setText(resources.getString("button.add"));
@@ -344,6 +348,7 @@ public class MainController extends AbstractController {
             argList.add(ArgName.toolkitProjectListNames + "=" + toolkitProjectListNamesTextField.getText());
         }
         argList.add(ArgName.deleteDownloadedFiles + "=" + deleteDownloadedFilesCheckBox.isSelected());
+        argList.add(ArgName.uploadAsHtml + "=" + uploadAsHtmlCheckBox.isSelected());
 
         argList.add(ArgName.projectPath + "=" + projectPathLabel.getText());
         argList.add(ArgName.itemPath + "=" + itemPathLabel.getText());
@@ -387,7 +392,8 @@ public class MainController extends AbstractController {
                 endDatePicker.setValue(LocalDate.now());
             }
             toolkitProjectListNamesTextField.setDisable(uploadTypeComboBox.getValue() != UploadType.TOOLKIT_DOCS);
-            deleteDownloadedFilesCheckBox.setDisable(uploadTypeComboBox.getValue() != UploadType.TOOLKIT_DOCS);
+            deleteDownloadedFilesCheckBox.setDisable(uploadTypeComboBox.getValue() != UploadType.TOOLKIT_DOCS || uploadAsHtmlCheckBox.isSelected());
+            uploadAsHtmlCheckBox.setDisable(uploadTypeComboBox.getValue() != UploadType.TOOLKIT_DOCS);
             endDatePicker.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
             authorsTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
             committerEmailTextField.setDisable(uploadTypeComboBox.getValue() == UploadType.TOOLKIT_DOCS);
@@ -499,6 +505,9 @@ public class MainController extends AbstractController {
                 startupService.disableStartOnStartup();
             }
         });
+
+        uploadAsHtmlCheckBox.selectedProperty().addListener((observable, oldValue, newValue) ->
+                deleteDownloadedFilesCheckBox.setDisable(newValue));
     }
 
 }

--- a/src/main/java/pg/gipter/ui/main/MainController.java
+++ b/src/main/java/pg/gipter/ui/main/MainController.java
@@ -418,6 +418,8 @@ public class MainController extends AbstractController {
             properties.replace(ArgName.preferredArgSource.name(), PreferredArgSource.FILE.name());
             propertiesHelper.saveToApplicationProperties(properties);
         } else {
+            properties.remove(ArgName.startDate.name());
+            properties.remove(ArgName.endDate.name());
             propertiesHelper.saveToUIApplicationProperties(properties);
         }
     }

--- a/src/main/resources/bundle/translation.properties
+++ b/src/main/resources/bundle/translation.properties
@@ -49,6 +49,7 @@ paths.panel.title= Paths details
 paths.panel.projectPath= Project paths
 paths.panel.itemPath= Item path
 paths.panel.fileNamePrefix= File name prefix
+paths.panel.useAsFileName= Use prefix as file name
 
 popup.title= Ku kuu ryy kuuu!
 popup.header.error= Oh Chicken Face ('>

--- a/src/main/resources/bundle/translation.properties
+++ b/src/main/resources/bundle/translation.properties
@@ -44,6 +44,7 @@ toolkit.panel.wsUrl= WS Url
 toolkit.panel.userFolder= User folder
 toolkit.panel.projectListNames= List names
 toolkit.panel.deleteFiles= Delete downloaded files
+toolkit.panel.uploadAsHtml= Upload as html
 
 paths.panel.title= Paths details
 paths.panel.projectPath= Project paths

--- a/src/main/resources/bundle/translation_pl.properties
+++ b/src/main/resources/bundle/translation_pl.properties
@@ -63,6 +63,7 @@ toolkit.panel.wsUrl= WS Url
 toolkit.panel.userFolder= Folder
 toolkit.panel.projectListNames= Nazwy list
 toolkit.panel.deleteFiles= Usu\u0144 zassane pliki
+toolkit.panel.uploadAsHtml= Wrzuć jako html
 
 paths.panel.title= \u015Acie\u017Cki
 paths.panel.projectPath= Projekt

--- a/src/main/resources/bundle/translation_pl.properties
+++ b/src/main/resources/bundle/translation_pl.properties
@@ -68,6 +68,7 @@ paths.panel.title= \u015Acie\u017Cki
 paths.panel.projectPath= Projekt
 paths.panel.itemPath= Utw\u00F3r
 paths.panel.fileNamePrefix= Prefix pliku
+paths.panel.useAsFileName= U\u017Cyj prefixu jako nazwy pliku
 
 popup.title= Ku kuu ryy kuuu!
 popup.header.error= O Kurza Twarz ('>

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -139,8 +139,10 @@
                      </font></TextField>
                   <TextField fx:id="toolkitProjectListNamesTextField" layoutX="359.0" layoutY="7.0" prefHeight="25.0" prefWidth="233.0" />
                   <Label layoutX="284.0" layoutY="11.0" text="%toolkit.panel.projectListNames" />
-                  <CheckBox fx:id="deleteDownloadedFilesCheckBox" layoutX="423.0" layoutY="42.0" mnemonicParsing="false" />
+                  <CheckBox fx:id="deleteDownloadedFilesCheckBox" layoutX="422.0" layoutY="42.0" mnemonicParsing="false" />
                   <Label layoutX="284.0" layoutY="42.0" text="%toolkit.panel.deleteFiles" />
+                  <Label layoutX="284.0" layoutY="69.0" text="%toolkit.panel.uploadAsHtml" />
+                  <CheckBox fx:id="uploadAsHtmlCheckBox" layoutX="422.0" layoutY="69.0" mnemonicParsing="false" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -58,6 +58,7 @@
                      <font>
                         <Font name="System Bold" size="11.0" />
                      </font></Button>
+                  <CheckBox fx:id="useAsFileNameCheckBox" layoutX="302.0" layoutY="13.0" mnemonicParsing="false" text="%paths.panel.useAsFileName" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/test/java/pg/gipter/producer/processor/DocumentFinderFactoryTest.java
+++ b/src/test/java/pg/gipter/producer/processor/DocumentFinderFactoryTest.java
@@ -27,6 +27,20 @@ class DocumentFinderFactoryTest {
     }
 
     @Test
+    void givenUploadAsHtmlSetY_whenGetInstance_thenReturnHtmlDocumentFinder() {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.uploadAsHtml + "=" + true,
+                }
+        );
+
+        DocumentFinder documentFinder = DocumentFinderFactory.getInstance(applicationProperties);
+
+        AssertionsForClassTypes.assertThat(documentFinder).isInstanceOf(HtmlDocumentFinder.class);
+    }
+
+    @Test
     @Disabled("Until ComplexDocumentFinder is ready.")
     void givenEndDateNotEqualNow_whenGetInstance_thenReturnSimpleDocumentFinder() {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(

--- a/src/test/java/pg/gipter/producer/processor/HtmlDocumentFinderTest.java
+++ b/src/test/java/pg/gipter/producer/processor/HtmlDocumentFinderTest.java
@@ -33,7 +33,7 @@ class HtmlDocumentFinderTest {
     }
 
     @Test
-    void givenItemsJsonWithDatesInThePast_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsJsonWithDatesInThePast_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -49,11 +49,13 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(2);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(3.0);
         assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 31, 07));
         assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
@@ -61,7 +63,7 @@ class HtmlDocumentFinderTest {
 
 
     @Test
-    void givenItemsWithComplexHistory_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsWithComplexHistory_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -78,26 +80,30 @@ class HtmlDocumentFinderTest {
 
         assertThat(htmlDocuments).hasSize(4);
 
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(2.0);
         assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
         assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(3.0);
         assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
         assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(5.0);
         assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 28, 14, 31, 7));
         assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase2_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase2_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -113,14 +119,15 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(1);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase3_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase3_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -136,26 +143,30 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(4);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(2.0);
         assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
         assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(3.0);
         assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
         assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(4.0);
         assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
         assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase4_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase4_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -171,14 +182,15 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(1);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(4.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase5_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase5_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -197,7 +209,7 @@ class HtmlDocumentFinderTest {
     }
 
     @Test
-    void givenItemsCase6_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase6_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -213,14 +225,15 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(1);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(3.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase7_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase7_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -236,18 +249,20 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(2);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(4.0);
         assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
         assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
     }
 
     @Test
-    void givenItemsCase8_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+    void givenItemsCase8_whenGetFilesToDownload_thenReturnListOfHtmlDocs() throws IOException {
         ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
                 new String[]{
                         ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
@@ -265,19 +280,23 @@ class HtmlDocumentFinderTest {
         List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
 
         assertThat(htmlDocuments).hasSize(4);
-        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(38.0);
         assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 3, 29, 12, 29, 38));
         assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/19456/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(39.0);
         assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 5, 13, 56, 31));
         assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/19968/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(42.0);
         assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 9, 9, 16, 28));
         assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/21504/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
-        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getFileName()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master");
         assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(44.0);
         assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 12, 10, 01, 29));
         assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");

--- a/src/test/java/pg/gipter/producer/processor/HtmlDocumentFinderTest.java
+++ b/src/test/java/pg/gipter/producer/processor/HtmlDocumentFinderTest.java
@@ -1,0 +1,305 @@
+package pg.gipter.producer.processor;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import pg.gipter.settings.ApplicationProperties;
+import pg.gipter.settings.ApplicationPropertiesFactory;
+import pg.gipter.settings.ArgName;
+import pg.gipter.settings.PreferredArgSource;
+import pg.gipter.toolkit.dto.DocumentDetails;
+import pg.gipter.toolkit.helper.XmlHelper;
+import pg.gipter.utils.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HtmlDocumentFinderTest {
+
+    private HtmlDocumentFinder finder;
+
+    private JsonObject getJsonObject(String s) throws FileNotFoundException {
+        String path = XmlHelper.getFullXmlPath(s);
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(path));
+        Gson gson = new Gson();
+        return gson.fromJson(bufferedReader, JsonObject.class);
+    }
+
+    @Test
+    void givenItemsJsonWithDatesInThePast_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-25",
+                        ArgName.endDate + "=2019-04-06",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("customItem.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(2);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(3.0);
+        assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 31, 07));
+        assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+
+    @Test
+    void givenItemsWithComplexHistory_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-1.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(4);
+
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(2.0);
+        assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
+        assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(3.0);
+        assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
+        assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(5.0);
+        assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 28, 14, 31, 7));
+        assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase2_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-2.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(1);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase3_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-3.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(4);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(2.0);
+        assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 14, 22, 7));
+        assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3072/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(3.0);
+        assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
+        assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(4.0);
+        assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
+        assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase4_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-4.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(1);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(4.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase5_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-5.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).isEmpty();
+    }
+
+    @Test
+    void givenItemsCase6_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-6.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(1);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(3.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 7, 36, 38));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/4096/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase7_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-24",
+                        ArgName.endDate + "=2019-03-02",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-7.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(2);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(1.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 26, 13, 51, 27));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/2560/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(4.0);
+        assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 2, 27, 14, 31, 7));
+        assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/3584/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenItemsCase8_whenGetFilesToDownload_thenReturnMapWithFilesToDownload() throws IOException {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-04-01",
+                        ArgName.endDate + "=2019-04-13",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("Item-case-8.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js).stream()
+                .filter(dd -> !StringUtils.nullOrEmpty(dd.getDocType()))
+                .collect(toList());
+
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        assertThat(htmlDocuments).hasSize(4);
+        assertThat(htmlDocuments.get(0).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(0).getVersion()).isEqualTo(38.0);
+        assertThat(htmlDocuments.get(0).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 3, 29, 12, 29, 38));
+        assertThat(htmlDocuments.get(0).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/19456/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(1).getVersion()).isEqualTo(39.0);
+        assertThat(htmlDocuments.get(1).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 5, 13, 56, 31));
+        assertThat(htmlDocuments.get(1).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/19968/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(2).getVersion()).isEqualTo(42.0);
+        assertThat(htmlDocuments.get(2).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 9, 9, 16, 28));
+        assertThat(htmlDocuments.get(2).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/_vti_history/21504/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getTitle()).isEqualTo("D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+        assertThat(htmlDocuments.get(3).getVersion()).isEqualTo(44.0);
+        assertThat(htmlDocuments.get(3).getModificationDate()).isEqualTo(LocalDateTime.of(2019, 4, 12, 10, 01, 29));
+        assertThat(htmlDocuments.get(3).getLink()).isEqualTo("https://goto.netcompany.com/cases/GTE440/TOEDNLD/Deliverables/D0180 - Integration design/Topdanmark integrations/D0180 - Integration Design - Topdanmark integrations - Party Master.docx");
+    }
+
+    @Test
+    void givenDocumentDetails_whenCreateHtml_thenReturnHtml() throws Exception {
+        ApplicationProperties applicationProperties = ApplicationPropertiesFactory.getInstance(
+                new String[]{
+                        ArgName.preferredArgSource + "=" + PreferredArgSource.CLI.name(),
+                        ArgName.startDate + "=2019-02-25",
+                        ArgName.endDate + "=2019-04-06",
+                        ArgName.toolkitUsername + "=pawg",
+                        ArgName.projectPath + "=/cases/GTE440/TOEDNLD"
+                });
+        finder = new HtmlDocumentFinder(applicationProperties);
+        JsonObject js = getJsonObject("customItem.json");
+        List<DocumentDetails> documentDetails = finder.convertToDocumentDetails(js);
+        List<HtmlDocument> htmlDocuments = finder.getHtmlDocuments(documentDetails);
+
+        String html = finder.createHtml(htmlDocuments);
+
+        assertThat(html).isNotBlank();
+    }
+}

--- a/src/test/java/pg/gipter/settings/CliPreferredApplicationPropertiesTest.java
+++ b/src/test/java/pg/gipter/settings/CliPreferredApplicationPropertiesTest.java
@@ -1470,4 +1470,63 @@ class CliPreferredApplicationPropertiesTest {
 
         assertThat(actual).isFalse();
     }
+
+    @Test
+    void givenNoUseAsFileName_whenIsUseAsFileName_thenReturnDefault() {
+        applicationProperties = new CliPreferredApplicationProperties(new String[]{});
+
+        boolean actual = applicationProperties.isUseAsFileName();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenUseAsFileNameFromCLI_whenIsUseAsFileName_thenReturnCliUseAsFileName() {
+        applicationProperties = new CliPreferredApplicationProperties(
+                new String[]{"useAsFileName=y"}
+        );
+
+        boolean actual = applicationProperties.isUseAsFileName();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUseAsFileNameFileAndCLI_whenIsUseAsFileName_thenReturnCliUseAsFileName() {
+        String[] args = {"useAsFileName=y"};
+        Properties props = new Properties();
+        props.put("useAsFileName", "n");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUseAsFileName();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUseAsFileNameFromProperties_whenIsUseAsFileName_thenReturnUseAsFileNameFromProperties() {
+        String[] args = {};
+        Properties props = new Properties();
+        props.put("useAsFileName", "y");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUseAsFileName();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUseAsFileNameFromPropertiesAndOtherArgs_whenIsUseAsFileName_thenReturnUseAsFileNameFromProperties() {
+        String[] args = {"author=test"};
+        Properties props = new Properties();
+        props.put("useAsFileName", "y");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUseAsFileName();
+
+        assertThat(actual).isTrue();
+    }
 }

--- a/src/test/java/pg/gipter/settings/CliPreferredApplicationPropertiesTest.java
+++ b/src/test/java/pg/gipter/settings/CliPreferredApplicationPropertiesTest.java
@@ -1529,4 +1529,63 @@ class CliPreferredApplicationPropertiesTest {
 
         assertThat(actual).isTrue();
     }
+
+    @Test
+    void givenNoUploadAsHtml_whenIsUploadAsHtml_thenReturnDefault() {
+        applicationProperties = new CliPreferredApplicationProperties(new String[]{});
+
+        boolean actual = applicationProperties.isUploadAsHtml();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenUploadAsHtmlFromCLI_whenIsUploadAsHtml_thenReturnCliUploadAsHtml() {
+        applicationProperties = new CliPreferredApplicationProperties(
+                new String[]{"uploadAsHtml=y"}
+        );
+
+        boolean actual = applicationProperties.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUploadAsHtmlFileAndCLI_whenIsUploadAsHtml_thenReturnCliUploadAsHtml() {
+        String[] args = {"uploadAsHtml=y"};
+        Properties props = new Properties();
+        props.put("uploadAsHtml", "n");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUploadAsHtmlFromProperties_whenIsUploadAsHtml_thenReturnUploadAsHtmlFromProperties() {
+        String[] args = {};
+        Properties props = new Properties();
+        props.put("uploadAsHtml", "y");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUploadAsHtmlFromPropertiesAndOtherArgs_whenIsUploadAsHtml_thenReturnUploadAsHtmlFromProperties() {
+        String[] args = {"author=test"};
+        Properties props = new Properties();
+        props.put("uploadAsHtml", "y");
+        applicationProperties = new CliPreferredApplicationProperties(args);
+        applicationProperties.init(args, mockPropertiesLoader(props));
+
+        boolean actual = applicationProperties.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
 }

--- a/src/test/java/pg/gipter/settings/FilePreferredApplicationPropertiesTest.java
+++ b/src/test/java/pg/gipter/settings/FilePreferredApplicationPropertiesTest.java
@@ -248,6 +248,31 @@ class FilePreferredApplicationPropertiesTest {
     }
 
     @Test
+    void givenUseAsFileNameYAndFileNamePrefixAndToolkitDocs_whenFileName_thenReturnFileNamePrefixAsNameWithZip() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.uploadType.name() + "=" + UploadType.TOOLKIT_DOCS.name(),
+                ArgName.itemFileNamePrefix + "=my_custom_name",
+                ArgName.useAsFileName + "=Y",
+        });
+
+        String actual = appProps.fileName();
+
+        assertThat(actual).endsWith("my_custom_name.zip");
+    }
+
+    @Test
+    void givenUseAsFileNameYAndFileNamePrefix_whenFileName_thenReturnFileNamePrefixAsNameWithTxt() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.itemFileNamePrefix + "=my_custom_name",
+                ArgName.useAsFileName + "=Y",
+        });
+
+        String actual = appProps.fileName();
+
+        assertThat(actual).endsWith("my_custom_name.txt");
+    }
+
+    @Test
     void given_periodInDaysAndStartDate_when_startDate_then_returnStartDate() {
         appProps = new FilePreferredApplicationProperties(new String[]{"periodInDays=16","startDate=2018-10-18"});
 
@@ -808,6 +833,44 @@ class FilePreferredApplicationPropertiesTest {
         appProps.init(args, mockPropertiesLoader(props));
 
         boolean actual = appProps.isEnableOnStartup();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenEmptyUseAsFileNameFiles_whenIsUseAsFileName_thenReturnFalse() {
+        String[] args = {""};
+        Properties props = new Properties();
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUseAsFileName();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenUseAsFileNameSetY_whenIsUseAsFileName_thenReturnTrue() {
+        String[] args = {"useAsFileName=N"};
+        Properties props = new Properties();
+        props.put("useAsFileName", "Y");
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUseAsFileName();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUseAsFileNameN_whenIsUseAsFileName_thenReturnFalse() {
+        String[] args = {""};
+        Properties props = new Properties();
+        props.put("useAsFileName", "n");
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUseAsFileName();
 
         assertThat(actual).isFalse();
     }

--- a/src/test/java/pg/gipter/settings/FilePreferredApplicationPropertiesTest.java
+++ b/src/test/java/pg/gipter/settings/FilePreferredApplicationPropertiesTest.java
@@ -257,7 +257,7 @@ class FilePreferredApplicationPropertiesTest {
 
         String actual = appProps.fileName();
 
-        assertThat(actual).endsWith("my_custom_name.zip");
+        assertThat(actual).isEqualTo("my_custom_name.zip");
     }
 
     @Test
@@ -269,7 +269,34 @@ class FilePreferredApplicationPropertiesTest {
 
         String actual = appProps.fileName();
 
-        assertThat(actual).endsWith("my_custom_name.txt");
+        assertThat(actual).isEqualTo("my_custom_name.txt");
+    }
+
+    @Test
+    void givenUseAsFileNameYAndFileNamePrefixAndUploadAsHtml_whenFileName_thenReturnFileNamePrefixAsNameWithTxt() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.itemFileNamePrefix + "=my_custom_name",
+                ArgName.useAsFileName + "=Y",
+                ArgName.uploadAsHtml + "=Y",
+        });
+
+        String actual = appProps.fileName();
+
+        assertThat(actual).isEqualTo("my_custom_name.txt");
+    }
+
+    @Test
+    void givenUseAsFileNameYAndFileNamePrefixAndUploadAsHtmlAndUploadTypeToolkitDocs_whenFileName_thenReturnFileNamePrefixAsNameWithHtml() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.uploadType.name() + "=" + UploadType.TOOLKIT_DOCS.name(),
+                ArgName.itemFileNamePrefix + "=my_custom_name",
+                ArgName.useAsFileName + "=Y",
+                ArgName.uploadAsHtml + "=Y",
+        });
+
+        String actual = appProps.fileName();
+
+        assertThat(actual).isEqualTo("my_custom_name.html");
     }
 
     @Test
@@ -762,6 +789,16 @@ class FilePreferredApplicationPropertiesTest {
     }
 
     @Test
+    void givenNoProperties_whenIsDeleteDownloadedFiles_thenReturnTrue() {
+        String[] args = {""};
+        appProps = new FilePreferredApplicationProperties(args);
+
+        boolean actual = appProps.isDeleteDownloadedFiles();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
     void givenEmptyDeleteDownloadedFiles_whenIsDeleteDownloadedFiles_thenReturnTrue() {
         String[] args = {""};
         Properties props = new Properties();
@@ -795,6 +832,16 @@ class FilePreferredApplicationPropertiesTest {
         appProps.init(args, mockPropertiesLoader(props));
 
         boolean actual = appProps.isDeleteDownloadedFiles();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenNoProperties_whenIsEnableOnStartup_thenReturnTrue() {
+        String[] args = {""};
+        appProps = new FilePreferredApplicationProperties(args);
+
+        boolean actual = appProps.isEnableOnStartup();
 
         assertThat(actual).isTrue();
     }
@@ -838,6 +885,16 @@ class FilePreferredApplicationPropertiesTest {
     }
 
     @Test
+    void givenNoProperties_whenIsUseAsFileName_thenReturnFalse() {
+        String[] args = {""};
+        appProps = new FilePreferredApplicationProperties(args);
+
+        boolean actual = appProps.isUseAsFileName();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
     void givenEmptyUseAsFileNameFiles_whenIsUseAsFileName_thenReturnFalse() {
         String[] args = {""};
         Properties props = new Properties();
@@ -873,5 +930,88 @@ class FilePreferredApplicationPropertiesTest {
         boolean actual = appProps.isUseAsFileName();
 
         assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenNoProperties_whenIsUploadAsHtml_thenReturnFalse() {
+        String[] args = {""};
+        appProps = new FilePreferredApplicationProperties(args);
+
+        boolean actual = appProps.isUploadAsHtml();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenUploadAsHtmlFiles_whenIsUploadAsHtml_thenReturnFalse() {
+        String[] args = {""};
+        Properties props = new Properties();
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUploadAsHtml();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void givenUploadAsHtmlSetY_whenIsUploadAsHtml_thenReturnTrue() {
+        String[] args = {"uploadAsHtml=N"};
+        Properties props = new Properties();
+        props.put("uploadAsHtml", "Y");
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUploadAsHtmlSetN_whenIsUploadAsHtml_thenReturnTrue() {
+        String[] args = {""};
+        Properties props = new Properties();
+        props.put("uploadAsHtml", "y");
+        appProps = new FilePreferredApplicationProperties(args);
+        appProps.init(args, mockPropertiesLoader(props));
+
+        boolean actual = appProps.isUploadAsHtml();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void givenUploadAsHtmlAndUploadTypeToolkitDocs_whenGetFileExtension_thenReturnHtml() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.uploadType.name() + "=" + UploadType.TOOLKIT_DOCS.name(),
+                ArgName.uploadAsHtml + "=Y",
+        });
+
+        String actual = appProps.getFileExtension();
+
+        assertThat(actual).isEqualTo("html");
+    }
+
+    @Test
+    void givenUploadAsHtmlSetNAndUploadTypeToolkitDocs_whenGetFileExtension_thenReturnZip() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.uploadType.name() + "=" + UploadType.TOOLKIT_DOCS.name(),
+                ArgName.uploadAsHtml + "=N",
+        });
+
+        String actual = appProps.getFileExtension();
+
+        assertThat(actual).isEqualTo("zip");
+    }
+
+    @Test
+    void givenUploadAsHtmlSetY_whenGetFileExtension_thenReturnTxt() {
+        appProps = new FilePreferredApplicationProperties(new String[]{
+                ArgName.uploadAsHtml + "=Y",
+        });
+
+        String actual = appProps.getFileExtension();
+
+        assertThat(actual).isEqualTo("txt");
     }
 }


### PR DESCRIPTION
* Adding `useAsFileName` to use `itemFileNamePrefix` as replacement for generated item file name,
* Adding `uploadAsHtml` to produce item in form of html with links to documents,
* Removing `startDate` and `endDate` saving configuration from UI.  