### PR TITLE
Configure powershell options when generating diff on Windows

### DIFF
--- a/src/main/java/pg/gipter/core/producers/AbstractDiffProducer.java
+++ b/src/main/java/pg/gipter/core/producers/AbstractDiffProducer.java
@@ -170,6 +170,9 @@ abstract class AbstractDiffProducer implements DiffProducer {
         DiffDetails diffDetails = new DiffDetails(projectPath);
         LinkedList<String> fullCommand = new LinkedList<>();
         fullCommand.add("powershell.exe");
+        fullCommand.add("-NoProfile");
+        fullCommand.add("-NoLogo");
+        fullCommand.add("-NonInteractive");
         fullCommand.addAll(cmd);
         ProcessBuilder processBuilder = new ProcessBuilder(fullCommand);
         processBuilder.directory(Paths.get(projectPath).toFile());


### PR DESCRIPTION
Skip PowerShell profile loading, logo and run as non-interactive when producing diff on Windows